### PR TITLE
read: print byte as 2-digit hex

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# See https://help.github.com/articles/about-codeowners/
+* @thistletech/engineering

--- a/src/cmds.rs
+++ b/src/cmds.rs
@@ -90,7 +90,7 @@ pub fn read(device: String, slot: u16, raw: bool) -> Result<()> {
 
     let pk = &pk[9..73];
     eprintln!("~~ Key at slot {:#04x}", slot);
-    eprintln!("{:x?}", pk);
+    eprintln!("{:02x?}", pk);
 
     if raw {
         std::io::stdout().write_all(pk)?;


### PR DESCRIPTION
This is a minor formatting improvement.

Before:

```bash
$ tmtool-aarch64 --key-slot 0xe0e8 read
~~ TrustM initinialised
~~ Key at slot 0xe0e8
[e2, b, 5, c4, f7, 97, 40, 1, f7, 64, 8f, ff, 38, 41, 5, a1, 85, 89, af, c3, ca, 56, d5, 96, 57, 75, 4c, 42, 14, 9, 8f, 7f, 80, 84, bb, 6c, d0, 92, 52, 37, 4e, 81, b1, 22, 6a, 26, cd, 23, 85, 55, 88, 87, 58, 9b, 79, f9, 11, 8c, ec, 6f, 4, cb, bd, 63]
```

After:

```bash
$ tmtool-aarch64 --key-slot 0xe0e8 read
~~ TrustM initinialised
~~ Key at slot 0xe0e8
[e2, 0b, 05, c4, f7, 97, 40, 01, f7, 64, 8f, ff, 38, 41, 05, a1, 85, 89, af, c3, ca, 56, d5, 96, 57, 75, 4c, 42, 14, 09, 8f, 7f, 80, 84, bb, 6c, d0, 92, 52, 37, 4e, 81, b1, 22, 6a, 26, cd, 23, 85, 55, 88, 87, 58, 9b, 79, f9, 11, 8c, ec, 6f, 04, cb, bd, 63]
```